### PR TITLE
Added wait until element is visible

### DIFF
--- a/src/browser/tab/element/mod.rs
+++ b/src/browser/tab/element/mod.rs
@@ -590,7 +590,7 @@ impl<'a> Element<'a> {
     }
 
     pub fn is_visible(&self) -> Result<bool> {
-         self.is_visible_with_timeout(Duration::from_secs(3))
+        self.is_visible_with_timeout(Duration::from_secs(3))
     }
 
     pub fn is_visible_with_timeout(&self, timeout: Duration) -> Result<bool> {
@@ -609,7 +609,6 @@ impl<'a> Element<'a> {
 
         Ok(p)
     }
-
 }
 
 #[derive(Debug, Error)]

--- a/src/browser/tab/element/mod.rs
+++ b/src/browser/tab/element/mod.rs
@@ -588,6 +588,28 @@ impl<'a> Element<'a> {
 
         util::extract_midpoint(result)
     }
+
+    pub fn is_visible(&self) -> Result<bool> {
+         self.is_visible_with_timeout(Duration::from_secs(3))
+    }
+
+    pub fn is_visible_with_timeout(&self, timeout: Duration) -> Result<bool> {
+        let p = util::Wait::with_timeout(timeout).until(|| {
+            let r = self.call_js_fn(
+                "function() { return this.checkVisibility(); }",
+                vec![],
+                false,
+            );
+
+            match r {
+                Ok(x) => x.value.unwrap().as_bool(),
+                Err(_) => Some(false),
+            }
+        })?;
+
+        Ok(p)
+    }
+
 }
 
 #[derive(Debug, Error)]

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -175,6 +175,10 @@ pub struct Tab {
 pub struct NoElementFound {}
 
 #[derive(Debug, Error)]
+#[error("Element not visible")]
+pub struct ElementNotVisible {}
+
+#[derive(Debug, Error)]
 #[error("Navigate failed: {error_text}")]
 pub struct NavigationFailed {
     error_text: String,
@@ -632,6 +636,35 @@ impl Tab {
         debug!("Waiting for element with selector: {selector:?}");
         util::Wait::with_timeout(timeout).strict_until(
             || self.find_element(selector),
+            Error::downcast::<NoElementFound>,
+        )
+    }
+
+    pub fn wait_until_visible(
+        &self,
+        selector: &str,
+    ) -> Result<Element<'_>> {
+        self.wait_until_visible_with_custom_timeout(selector, *self.default_timeout.read().unwrap())
+    }
+
+    pub fn wait_until_visible_with_custom_timeout(
+        &self,
+        selector: &str,
+        timeout: std::time::Duration,
+    ) -> Result<Element<'_>> {
+        debug!("Waiting for element with selector to be visible: {:?}", selector);
+        util::Wait::with_timeout(timeout).strict_until(
+            || {
+                match self.find_element(selector) {
+                    Ok(elm) => {
+                        match elm.is_visible_with_timeout(timeout) {
+                            Ok(_) => Ok(elm),
+                            Err(_) => Err(Error::msg("Element not visible")),
+                        }
+                    },
+                    Err(_) => Err(Error::msg("Element not found in DOM")),
+                }
+            },
             Error::downcast::<NoElementFound>,
         )
     }

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -640,10 +640,7 @@ impl Tab {
         )
     }
 
-    pub fn wait_until_visible(
-        &self,
-        selector: &str,
-    ) -> Result<Element<'_>> {
+    pub fn wait_until_visible(&self, selector: &str) -> Result<Element<'_>> {
         self.wait_until_visible_with_custom_timeout(selector, *self.default_timeout.read().unwrap())
     }
 
@@ -652,18 +649,14 @@ impl Tab {
         selector: &str,
         timeout: std::time::Duration,
     ) -> Result<Element<'_>> {
-        debug!("Waiting for element with selector to be visible: {:?}", selector);
+        debug!("Waiting for element with selector to be visible: {selector:?}");
         util::Wait::with_timeout(timeout).strict_until(
-            || {
-                match self.find_element(selector) {
-                    Ok(elm) => {
-                        match elm.is_visible_with_timeout(timeout) {
-                            Ok(_) => Ok(elm),
-                            Err(_) => Err(Error::msg("Element not visible")),
-                        }
-                    },
-                    Err(_) => Err(Error::msg("Element not found in DOM")),
-                }
+            || match self.find_element(selector) {
+                Ok(elm) => match elm.is_visible_with_timeout(timeout) {
+                    Ok(_) => Ok(elm),
+                    Err(_) => Err(Error::msg("Element not visible")),
+                },
+                Err(_) => Err(Error::msg("Element not found in DOM")),
             },
             Error::downcast::<NoElementFound>,
         )


### PR DESCRIPTION
Sometimes, when running certain JavaScript, elements are added to the DOM at a later moment or are not yet visible. In those cases, interacting with the element is not possible.

To handle this, `wait_until_visible` waits until the element becomes visible on the page. By default, it waits for 3 seconds. If more time is needed, `wait_until_visible_with_custom_timeout` allows you to specify a longer timeout.

This uses the JavaScript [`checkVisibility()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility) function on the element.

> Note: I’m not sure about with the naming convention, so better name suggestions are very welcome.