### PR TITLE
Rustls tls webpki roots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,9 @@ tungstenite = "0.28"
 url = "2.5"
 which = "8.0"
 zip = { version = "6.0.0", optional = true }
-rustls = { version = "0.23" }
-rustls-pemfile = "2.2.0"
+rustls = { version = "0.23", optional = true }
+rustls-pemfile = { version = "2.2.0", optional = true }
+webpki-roots = { version = "1.0.7", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55.0"
@@ -55,5 +56,5 @@ fetch = ["ureq", "directories", "zip", "walkdir"]
 nightly = []
 offline = ["auto_generate_cdp/offline"]
 rustls-tls-native-roots = ["tungstenite/rustls", "tungstenite/rustls-tls-native-roots"]
-rustls-tls-webpki-roots = ["tungstenite/rustls", "tungstenite/rustls-tls-webpki-roots", "rustls/ring"]
+rustls-tls-webpki-roots = ["tungstenite/rustls", "tungstenite/rustls-tls-webpki-roots", "rustls", "rustls-pemfile", "webpki-roots",  "rustls/ring"]
 native-tls = ["tungstenite/native-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ tungstenite = "0.28"
 url = "2.5"
 which = "8.0"
 zip = { version = "6.0.0", optional = true }
+rustls = { version = "0.23" }
+rustls-pemfile = "2.2.0"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55.0"
@@ -52,5 +54,6 @@ default = ["offline"]
 fetch = ["ureq", "directories", "zip", "walkdir"]
 nightly = []
 offline = ["auto_generate_cdp/offline"]
-rustls = ["tungstenite/rustls", "tungstenite/rustls-tls-native-roots"]
+rustls-tls-native-roots = ["tungstenite/rustls", "tungstenite/rustls-tls-native-roots"]
+rustls-tls-webpki-roots = ["tungstenite/rustls", "tungstenite/rustls-tls-webpki-roots", "rustls/ring"]
 native-tls = ["tungstenite/native-tls"]

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -103,6 +103,7 @@ impl Browser {
             process.debug_ws_url.clone(),
             Some(process_id),
             idle_browser_timeout,
+            None
         )?);
 
         Self::create_browser(Some(process), transport, idle_browser_timeout, true)
@@ -123,6 +124,16 @@ impl Browser {
         Self::connect_with_timeout(debug_ws_url, Duration::from_secs(30))
     }
 
+    pub fn connect_with_root_cert(
+        debug_ws_url: String,
+        root_cert: Vec<u8>,
+    ) -> Result<Self> {
+        let url = Url::parse(&debug_ws_url)?;
+        let transport = Arc::new(Transport::new(url, None, Duration::from_secs(20), Some(root_cert))?);
+        trace!("created transport");
+        Self::create_browser(None, transport, Duration::from_secs(20), false)
+    }
+
     /// Allows you to drive an externally-launched Chrome process instead of launch one via [`Browser::new`].
     /// If the browser is idle for `idle_browser_timeout`, the connection will be dropped.
     pub fn connect_with_timeout(
@@ -131,7 +142,7 @@ impl Browser {
     ) -> Result<Self> {
         let url = Url::parse(&debug_ws_url)?;
 
-        let transport = Arc::new(Transport::new(url, None, idle_browser_timeout)?);
+        let transport = Arc::new(Transport::new(url, None, idle_browser_timeout, None)?);
         trace!("created transport");
 
         Self::create_browser(None, transport, idle_browser_timeout, false)

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -103,7 +103,7 @@ impl Browser {
             process.debug_ws_url.clone(),
             Some(process_id),
             idle_browser_timeout,
-            None
+            None,
         )?);
 
         Self::create_browser(Some(process), transport, idle_browser_timeout, true)
@@ -124,12 +124,14 @@ impl Browser {
         Self::connect_with_timeout(debug_ws_url, Duration::from_secs(30))
     }
 
-    pub fn connect_with_root_cert(
-        debug_ws_url: String,
-        root_cert: Vec<u8>,
-    ) -> Result<Self> {
+    pub fn connect_with_root_cert(debug_ws_url: String, root_cert: Vec<u8>) -> Result<Self> {
         let url = Url::parse(&debug_ws_url)?;
-        let transport = Arc::new(Transport::new(url, None, Duration::from_secs(20), Some(root_cert))?);
+        let transport = Arc::new(Transport::new(
+            url,
+            None,
+            Duration::from_secs(20),
+            Some(root_cert),
+        )?);
         trace!("created transport");
         Self::create_browser(None, transport, Duration::from_secs(20), false)
     }

--- a/src/browser/transport/mod.rs
+++ b/src/browser/transport/mod.rs
@@ -77,8 +77,12 @@ impl Transport {
         root_cert: Option<Vec<u8>>,
     ) -> Result<Self> {
         let (messages_tx, messages_rx) = mpsc::channel();
-        let web_socket_connection =
-            Arc::new(WebSocketConnection::new(&ws_url, process_id, messages_tx, root_cert)?);
+        let web_socket_connection = Arc::new(WebSocketConnection::new(
+            &ws_url,
+            process_id,
+            messages_tx,
+            root_cert,
+        )?);
 
         let waiting_call_registry = Arc::new(WaitingCallRegistry::new());
 

--- a/src/browser/transport/mod.rs
+++ b/src/browser/transport/mod.rs
@@ -12,7 +12,6 @@ use anyhow::Result;
 use thiserror::Error;
 
 use log::{error, info, trace, warn};
-
 use url::Url;
 use waiting_call_registry::WaitingCallRegistry;
 use web_socket_connection::WebSocketConnection;
@@ -29,6 +28,7 @@ mod web_socket_connection;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SessionId(String);
 
+#[derive(Debug)]
 pub enum MethodDestination {
     Target(SessionId),
     Browser,
@@ -74,10 +74,11 @@ impl Transport {
         ws_url: Url,
         process_id: Option<u32>,
         idle_browser_timeout: Duration,
+        root_cert: Option<Vec<u8>>,
     ) -> Result<Self> {
         let (messages_tx, messages_rx) = mpsc::channel();
         let web_socket_connection =
-            Arc::new(WebSocketConnection::new(&ws_url, process_id, messages_tx)?);
+            Arc::new(WebSocketConnection::new(&ws_url, process_id, messages_tx, root_cert)?);
 
         let waiting_call_registry = Arc::new(WaitingCallRegistry::new());
 

--- a/src/browser/transport/web_socket_connection.rs
+++ b/src/browser/transport/web_socket_connection.rs
@@ -1,7 +1,6 @@
 use std::net::TcpStream;
-use std::sync::Arc;
-use std::sync::Mutex;
 use std::sync::mpsc;
+use std::sync::{Arc, Mutex, Once};
 
 use anyhow::Result;
 use log::{debug, info, trace, warn};
@@ -10,11 +9,69 @@ use tungstenite::protocol::WebSocketConfig;
 use tungstenite::stream::MaybeTlsStream;
 use url::Url;
 
-use crate::types::{Message, parse_raw_message};
+use crate::types::{parse_raw_message, Message};
 
 type TungsteniteWebsocketConnection = tungstenite::protocol::WebSocket<MaybeTlsStream<TcpStream>>;
 
 const READ_TIMEOUT_DURATION: std::time::Duration = std::time::Duration::from_millis(100);
+
+#[cfg(feature = "rustls-tls-webpki-roots")]
+static RUSTLS_INIT: Once = Once::new();
+
+#[cfg(feature = "rustls-tls-webpki-roots")]
+fn init_rustls_provider() {
+    RUSTLS_INIT.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
+#[cfg(feature = "rustls-tls-webpki-roots")]
+fn add_root_certificates(
+    roots: &mut rustls::RootCertStore,
+    root_cert: Option<&[u8]>,
+) -> Result<()> {
+    use std::io::Cursor;
+
+    let Some(cert_bytes) = root_cert else {
+        return Ok(());
+    };
+
+    if cert_bytes.starts_with(b"-----BEGIN CERTIFICATE-----") {
+        let mut reader = Cursor::new(cert_bytes);
+
+        for cert in rustls_pemfile::certs(&mut reader) {
+            roots.add(cert?)?;
+        }
+    } else {
+        roots.add(rustls::pki_types::CertificateDer::from(cert_bytes.to_vec()))?;
+    }
+
+    Ok(())
+}
+
+fn set_read_timeout(stream: &mut MaybeTlsStream<TcpStream>) -> Result<()> {
+    let tcp_stream = match stream {
+        MaybeTlsStream::Plain(s) => s,
+
+        #[cfg(any(
+            feature = "rustls-tls-native-roots",
+            feature = "rustls-tls-webpki-roots"
+        ))]
+        MaybeTlsStream::Rustls(s) => &mut s.sock,
+
+        #[cfg(feature = "native-tls")]
+        MaybeTlsStream::NativeTls(s) => s.get_mut(),
+
+        #[allow(unreachable_patterns)]
+        _ => {
+            return Err(anyhow::anyhow!("unsupported websocket stream type"));
+        }
+    };
+
+    tcp_stream.set_read_timeout(Some(READ_TIMEOUT_DURATION))?;
+
+    Ok(())
+}
 
 pub struct WebSocketConnection {
     connection: Arc<Mutex<TungsteniteWebsocketConnection>>,
@@ -22,7 +79,6 @@ pub struct WebSocketConnection {
     process_id: Option<u32>,
 }
 
-// TODO websocket::sender::Writer is not :Debug...
 impl std::fmt::Debug for WebSocketConnection {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         write!(f, "WebSocketConnection {{}}")
@@ -34,13 +90,16 @@ impl WebSocketConnection {
         ws_url: &Url,
         process_id: Option<u32>,
         messages_tx: mpsc::Sender<Message>,
+        root_cert: Option<Vec<u8>>,
     ) -> Result<Self> {
-        let (connection, _) = Self::websocket_connection(ws_url)?;
+        let (connection, _) =
+            Self::websocket_connection_with_root_cert(ws_url, root_cert.as_deref())?;
 
         let connection = Arc::new(Mutex::new(connection));
 
         let thread = {
             let sender = connection.clone();
+
             std::thread::spawn(move || {
                 trace!("Starting msg dispatching loop");
                 Self::dispatch_incoming_messages(sender, messages_tx, process_id);
@@ -60,14 +119,18 @@ impl WebSocketConnection {
             "Shutting down WebSocket connection for Chrome {:?}",
             self.process_id
         );
-        if let Err(err) = self.connection.lock().unwrap().close(None) {
-            debug!(
-                "Couldn't shut down WS connection for Chrome {:?}: {}",
-                self.process_id, err
-            );
+
+        if let Ok(mut connection) = self.connection.lock() {
+            if let Err(err) = connection.close(None) {
+                debug!(
+                    "Couldn't shut down WS connection for Chrome {:?}: {}",
+                    self.process_id, err
+                );
+            }
+
+            connection.flush().ok();
         }
 
-        self.connection.lock().unwrap().flush().ok();
         self.thread.thread().unpark();
     }
 
@@ -77,7 +140,13 @@ impl WebSocketConnection {
         process_id: Option<u32>,
     ) {
         loop {
-            let message = receiver.lock().unwrap().read();
+            let message = match receiver.lock() {
+                Ok(mut receiver) => receiver.read(),
+                Err(err) => {
+                    debug!("WS mutex poisoned for Chrome #{process_id:?}: {err}");
+                    break;
+                }
+            };
 
             match message {
                 Err(err) => match err {
@@ -98,7 +167,8 @@ impl WebSocketConnection {
                         tungstenite::error::ProtocolError::ResetWithoutClosingHandshake,
                     ) => break,
                     error => {
-                        panic!("Unhandled WebSocket error for Chrome #{process_id:?}: {error:?}");
+                        debug!("Unhandled WebSocket error for Chrome #{process_id:?}: {error:?}");
+                        break;
                     }
                 },
                 Ok(message) => {
@@ -118,74 +188,113 @@ impl WebSocketConnection {
                                 debug!(
                                     "Received close frame from Chrome #{process_id:?}: {code:?} {reason:?}",
                                 );
-                                match code {
-                                    tungstenite::protocol::frame::coding::CloseCode::Normal => {
-                                        debug!("Normal close code, shutting down");
-                                    }
-                                    _ => {
-                                        panic!("Abnormal close code {code:?}, shutting down");
-                                    }
+
+                                if code
+                                    != tungstenite::protocol::frame::coding::CloseCode::Normal
+                                {
+                                    debug!("Abnormal close code {code:?}, shutting down");
                                 }
                             }
                             None => {
                                 debug!("Received close frame from Chrome #{process_id:?}: None");
                             }
                         }
+
                         break;
                     } else {
-                        panic!("Got a weird message: {message:?}");
+                        debug!("Ignoring unexpected WebSocket message: {message:?}");
                     }
                 }
             }
         }
 
         info!("Sending shutdown message to message handling loop");
+
         if messages_tx.send(Message::ConnectionShutdown).is_err() {
             warn!("Couldn't send message to transport loop telling it to shut down");
         }
     }
 
-    pub fn websocket_connection(
+    pub fn websocket_connection_with_root_cert(
         ws_url: &Url,
+        root_cert: Option<&[u8]>,
     ) -> Result<(
         tungstenite::WebSocket<MaybeTlsStream<TcpStream>>,
         Response<Option<Vec<u8>>>,
     )> {
-        let mut client = tungstenite::client::connect_with_config(
-            ws_url.as_str(),
-            Some(
-                WebSocketConfig::default()
-                    .accept_unmasked_frames(true)
-                    .max_message_size(None)
-                    .max_frame_size(None),
-            ),
-            u8::MAX - 1,
-        )?;
+        let config = Some(
+            WebSocketConfig::default()
+                .accept_unmasked_frames(true)
+                .max_message_size(None)
+                .max_frame_size(None),
+        );
 
-        let stream = client.0.get_mut();
+        if root_cert.is_none() {
+            let mut client =
+                tungstenite::client::connect_with_config(ws_url.as_str(), config, u8::MAX - 1)?;
 
-        // this should be handled in tungstenite
-        let stream = match stream {
-            MaybeTlsStream::Plain(s) => s,
-            #[cfg(feature = "native-tls")]
-            MaybeTlsStream::NativeTls(s) => s.get_mut(),
-            #[cfg(feature = "rustls")]
-            MaybeTlsStream::Rustls(s) => &mut s.sock,
+            set_read_timeout(client.0.get_mut())?;
 
-            _ => todo!(),
-        };
-        stream.set_read_timeout(Some(READ_TIMEOUT_DURATION))?;
+            debug!("Successfully connected to WebSocket: {ws_url}");
 
-        debug!("Successfully connected to WebSocket: {ws_url}");
+            return Ok(client);
+        }
 
-        Ok(client)
+        #[cfg(feature = "rustls-tls-webpki-roots")]
+        {
+            use tungstenite::client::IntoClientRequest;
+
+            init_rustls_provider();
+
+            let host = ws_url
+                .host_str()
+                .ok_or_else(|| anyhow::anyhow!("missing websocket host: {ws_url}"))?;
+
+            let port = ws_url
+                .port_or_known_default()
+                .ok_or_else(|| anyhow::anyhow!("missing websocket port: {ws_url}"))?;
+
+            let tcp = TcpStream::connect((host, port))?;
+
+            let mut roots = rustls::RootCertStore::empty();
+            add_root_certificates(&mut roots, root_cert)?;
+
+            let tls_config = rustls::ClientConfig::builder()
+                .with_root_certificates(roots)
+                .with_no_client_auth();
+
+            let connector = tungstenite::Connector::Rustls(Arc::new(tls_config));
+            let request = ws_url.as_str().into_client_request()?;
+
+            let mut client =
+                tungstenite::client_tls_with_config(request, tcp, config, Some(connector))?;
+
+            set_read_timeout(client.0.get_mut())?;
+
+            debug!("Successfully connected to WebSocket with custom root cert: {ws_url}");
+
+            Ok(client)
+        }
+
+        #[cfg(not(feature = "rustls-tls-webpki-roots"))]
+        {
+            Err(anyhow::anyhow!(
+            "root_cert was provided, but feature rustls-tls-webpki-roots is not enabled"
+        ))
+        }
     }
 
     pub fn send_message(&self, message_text: &str) -> Result<()> {
         let message = tungstenite::protocol::Message::text(message_text);
-        let mut sender = self.connection.lock().unwrap();
+
+        let mut sender = self
+            .connection
+            .lock()
+            .map_err(|err| anyhow::anyhow!("WS mutex poisoned: {err}"))?;
+
         sender.send(message)?;
         self.thread.thread().unpark();
+
         Ok(())
     }
 }

--- a/src/browser/transport/web_socket_connection.rs
+++ b/src/browser/transport/web_socket_connection.rs
@@ -9,7 +9,7 @@ use tungstenite::protocol::WebSocketConfig;
 use tungstenite::stream::MaybeTlsStream;
 use url::Url;
 
-use crate::types::{parse_raw_message, Message};
+use crate::types::{Message, parse_raw_message};
 
 type TungsteniteWebsocketConnection = tungstenite::protocol::WebSocket<MaybeTlsStream<TcpStream>>;
 
@@ -189,9 +189,7 @@ impl WebSocketConnection {
                                     "Received close frame from Chrome #{process_id:?}: {code:?} {reason:?}",
                                 );
 
-                                if code
-                                    != tungstenite::protocol::frame::coding::CloseCode::Normal
-                                {
+                                if code != tungstenite::protocol::frame::coding::CloseCode::Normal {
                                     debug!("Abnormal close code {code:?}, shutting down");
                                 }
                             }
@@ -279,8 +277,8 @@ impl WebSocketConnection {
         #[cfg(not(feature = "rustls-tls-webpki-roots"))]
         {
             Err(anyhow::anyhow!(
-            "root_cert was provided, but feature rustls-tls-webpki-roots is not enabled"
-        ))
+                "root_cert was provided, but feature rustls-tls-webpki-roots is not enabled"
+            ))
         }
     }
 

--- a/src/browser/transport/web_socket_connection.rs
+++ b/src/browser/transport/web_socket_connection.rs
@@ -255,6 +255,8 @@ impl WebSocketConnection {
             let tcp = TcpStream::connect((host, port))?;
 
             let mut roots = rustls::RootCertStore::empty();
+            roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+
             add_root_certificates(&mut roots, root_cert)?;
 
             let tls_config = rustls::ClientConfig::builder()


### PR DESCRIPTION
## Add support for custom root certificates in WebSocket connections

### Background

`headless_chrome` currently relies on Tungstenite's default TLS configuration when establishing WebSocket connections to the Chrome DevTools endpoint.

In environments that use an internal PKI or private certificate authority, the DevTools WebSocket endpoint may be served using certificates that are not trusted by the system or bundled root stores. In such cases, establishing a connection fails with errors similar to:

```text
IO error: invalid peer certificate: UnknownIssuer
```

This makes it difficult to use `headless_chrome` in enterprise environments where internal services are exposed through TLS using private root certificates.

### What changes

This PR adds an alternative connection path that allows callers to provide additional root certificates when creating a WebSocket connection.

The implementation:

* Adds support for supplying custom root certificates as PEM or DER encoded bytes.
* Creates a dedicated Rustls `RootCertStore`.
* Loads the provided certificate(s) into the trust store.
* Establishes the WebSocket connection using a custom Rustls connector.
* Preserves the existing connection behavior when no custom certificate is provided.

The default behavior remains unchanged for existing users.

### Motivation

This change enables secure connections to Chrome DevTools endpoints that are exposed behind:

* internal PKI infrastructures
* enterprise reverse proxies
* self-hosted browser clusters
* private certificate authorities

without requiring global trust-store modifications or disabling certificate validation.

### Compatibility

The feature is completely opt-in.

If no custom root certificate is provided, the existing connection mechanism is used and behavior remains unchanged.
