### PR TITLE
don't shut down transport when browser listener disconnects

### DIFF
--- a/src/browser/transport/mod.rs
+++ b/src/browser/transport/mod.rs
@@ -331,7 +331,7 @@ impl Transport {
                                             event_string.chars().take(400).collect::<String>(),
                                             err
                                         );
-                                        break;
+                                        listeners.lock().unwrap().remove(&ListenerId::Browser);
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary

A disconnected browser event listener currently causes the entire transport layer to shut down.

When sending a browser event fails because the listener channel has already been dropped, the message handling loop exits. This triggers a transport shutdown, closes the websocket connection, marks the transport as closed, and cancels all outstanding method calls.

As a result, subsequent CDP operations fail with errors such as:

```
The underlying connection is closed
```

even though the browser itself is still running and previous CDP requests may have completed successfully.

## Root Cause

The transport loop treated a listener disconnect as a fatal transport error:

```rust
if let Err(err) = tx.send(browser_event.clone()) {
    warn!(...);
    break;
}
```

A listener channel closing is expected behaviour and should not terminate the browser transport.

## Changes

* Remove the transport shutdown behaviour when a browser listener disconnects.
* Remove the disconnected listener from the registry.
* Continue processing browser events and CDP messages normally.

## Result

The browser transport remains active even when a listener is dropped, preventing unexpected websocket shutdowns and subsequent connection closed errors.
This may address part of #498 by avoiding a full transport shutdown when an event listener disconnects unexpectedly.
